### PR TITLE
Fix for comment-conflict with labels

### DIFF
--- a/syntaxes/ca65.tmLanguage.json
+++ b/syntaxes/ca65.tmLanguage.json
@@ -161,7 +161,7 @@
 		"labels": {
 			"patterns": [{
 				"name": "entity.name.label.ca65",
-				"match": "^\\s*\\S*:"
+				"match": "^\\s*[^;\\s]*:"
 			}]
 		}
 	},


### PR DESCRIPTION
I'm using some colons as a comment divider-bar and the following example is incorrectly identified as a label, as the colon(s) follow leading white-space:

```
.ifdef  OPTION_ORIGINAL
        ;:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
```

This proposed change ensures that semi-colons cannot be part of the label name.